### PR TITLE
Implement snake_case Conversion and fix inifinite loops

### DIFF
--- a/Sources/RevolutionKit/Rewriter/TestMethodNameConverter.swift
+++ b/Sources/RevolutionKit/Rewriter/TestMethodNameConverter.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct TestMethodNameConverter {
+    let shouldStripPrefix: Bool
+    private let testPrefix = "test"
+    private let snakeCasePrefix = "test_"
+    
+    /// Strip first `test` prefix from test case names.
+    /// `testCamelCase` -> `camelCase`
+    /// `test_snake_case` -> `snake_case`
+    /// `test` -> `test`
+    func convert(_ testMethodName: String) -> String {
+        guard shouldStripPrefix else { return testMethodName }
+        
+        if testMethodName.hasPrefix(snakeCasePrefix) {
+            return testMethodName.strippedFirst(snakeCasePrefix.count)
+        } else if testMethodName == testPrefix {
+            return testMethodName
+        } else if testMethodName.hasPrefix(testPrefix) {
+            return testMethodName
+                .strippedFirst(testPrefix.count)
+                .lowercasedFirstLetter()
+        }
+        assertionFailure("Unexpected call")
+        return testMethodName
+    }
+}
+
+extension String {
+    fileprivate func strippedFirst(_ k: Int) -> String {
+        var mutating = self
+        mutating.removeFirst(k)
+        return mutating
+    }
+    
+    fileprivate func lowercasedFirstLetter() -> String {
+        guard let firstLetter = first else { return self }
+        return firstLetter.lowercased() + self[index(after: startIndex)..<endIndex]
+    }
+}

--- a/Tests/RevolutionKitTests/TestMethodNameConverterTests.swift
+++ b/Tests/RevolutionKitTests/TestMethodNameConverterTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import RevolutionKit
+
+struct TestMethodNameConverterTests {
+    private static let fixtures = [
+        (true, "testDoSomething", "doSomething"),
+        (false, "testDoSomething", "testDoSomething"),
+        (true, "test_do_something", "do_something"),
+        (false, "test_do_something", "test_do_something"),
+        (true, "test", "test"),
+        (false, "test", "test"),
+    ]
+    
+    @Test("TestMethodNameConverter can convert method names", arguments: fixtures)
+    func testConversion(enableStripping: Bool, input: String, expected: String) {
+        let converter = TestMethodNameConverter(shouldStripPrefix: enableStripping)
+        
+        let actual = converter.convert(input)
+        #expect(actual == expected)
+    }
+}

--- a/Tests/RevolutionKitTests/TestMethodsTests.swift
+++ b/Tests/RevolutionKitTests/TestMethodsTests.swift
@@ -15,6 +15,26 @@ private let testCaseConversionFixtures: [ConversionTestFixture] = [
     ),
     .init(
         """
+        func test_do_something() {
+        }
+        """,
+        """
+        @Test func do_something() {
+        }
+        """
+    ),
+    .init(
+        """
+        func test() {
+        }
+        """,
+        """
+        @Test func test() {
+        }
+        """
+    ),
+    .init(
+        """
         @MainActor func testExample() {
         }
         """,


### PR DESCRIPTION
closes #7

This PR enables stripping `test_` prefixes from snake_named test names.

Additionally, I found the case causes an infinite loop. It fixes such a situation.