### PR TITLE
Ignore private methods in conversion

### DIFF
--- a/Sources/RevolutionKit/Rewriter/XCTestRewriter+MethodVisitor.swift
+++ b/Sources/RevolutionKit/Rewriter/XCTestRewriter+MethodVisitor.swift
@@ -96,7 +96,7 @@ extension XCTestRewriter {
     
     /// Returns a kind of the method
     private func detectMethodKind(of node: FunctionDeclSyntax) -> MethodKind? {
-        guard !isStaticMethod(node: node) else { return nil }
+        guard !isStaticOrPrivateMethod(node: node) else { return nil }
         
         return switch node.name.text {
         case let name where name.hasPrefix("test"):
@@ -111,10 +111,10 @@ extension XCTestRewriter {
         }
     }
     
-    /// Returns true if the method is static
-    private func isStaticMethod(node: FunctionDeclSyntax) -> Bool {
+    /// Returns true if the method is static or private
+    private func isStaticOrPrivateMethod(node: FunctionDeclSyntax) -> Bool {
         node.modifiers.contains {
-            $0.tokens(viewMode: .sourceAccurate).contains { $0.tokenKind == .keyword(.static) }
+            $0.name.tokenKind == .keyword(.static) || $0.name.tokenKind == .keyword(.private)
         }
     }
     

--- a/Tests/RevolutionKitTests/TestMethodsTests.swift
+++ b/Tests/RevolutionKitTests/TestMethodsTests.swift
@@ -76,6 +76,26 @@ private let testCaseConversionFixtures: [ConversionTestFixture] = [
         }
         """
     },
+    Fixture {
+        """
+        private func testExample() {
+        }
+        """
+        """
+        private func testExample() {
+        }
+        """
+    },
+    Fixture {
+        """
+        private static func testExample() {
+        }
+        """
+        """
+        private static func testExample() {
+        }
+        """
+    },
 ]
 
 private let setUpConversionFixtures: [ConversionTestFixture] = [


### PR DESCRIPTION
Private methods (even with a `test` prefix) are not considered test cases by XCTest.
